### PR TITLE
Rerankを実装する

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+COHERE_API_KEY=""

--- a/RAG_eval-LLM-As-A-Judge.py
+++ b/RAG_eval-LLM-As-A-Judge.py
@@ -1,6 +1,7 @@
 # Databricks notebook source
 # MAGIC %pip install databricks-langchain=0.1.1 langchain_cohere=0.2.4
 # MAGIC %pip install -U -qqqq  databricks-agents mlflow mlflow-skinny databricks-vectorsearch langchain==0.2.11 langchain_core==0.2.23 langchain_community==0.2.10
+# MAGIC %pip install python-dotenv
 # MAGIC %restart_python
 
 # COMMAND ----------
@@ -86,6 +87,7 @@ model_name = f"{catalog}.{dbName}.{registered_model_name}"
 with mlflow.start_run(run_name="new_eval_run"):
   evaluation_results = mlflow.evaluate(
       data=eval_set_df,
+      # data=exsample_eval_set,
       model=f"models:/{model_name}/{uc_model_info.version}",
       model_type="databricks-agent",
   )

--- a/RAG_eval-LLM-As-A-Judge.py
+++ b/RAG_eval-LLM-As-A-Judge.py
@@ -1,5 +1,5 @@
 # Databricks notebook source
-# MAGIC %pip install databricks-langchain=0.1.1
+# MAGIC %pip install databricks-langchain=0.1.1 langchain_cohere=0.2.4
 # MAGIC %pip install -U -qqqq  databricks-agents mlflow mlflow-skinny databricks-vectorsearch langchain==0.2.11 langchain_core==0.2.23 langchain_community==0.2.10
 # MAGIC %restart_python
 

--- a/RAG_eval-LLM-As-A-Judge.py
+++ b/RAG_eval-LLM-As-A-Judge.py
@@ -66,13 +66,8 @@ import pandas as pd
 exsample_eval_set  = [
     {
       "request_id": "1",
-      "request": "Zenith ZR-450のタッチスクリーン操作パネルの反応が鈍いです。どうしたら良いですか？",  # question
-      "expected_retrieved_context": [
-        {
-            "doc_uri": "https://example.com/1855",
-        }
-      ],
-      "expected_response": "Zenith ZR-450のタッチスクリーンが鈍い場合の具体的な対処法は以下の通りです：\n	1.	画面を清掃してください。\n	2.	改善しない場合は、ファームウェアのアップデートを確認してください。\n	3.	それでも解決しない場合は、サポートセンターに連絡して技術的なサポートを受けてください。\n\nこちらが正しい対応手順となります。"  # 模範解答
+      "request": "AO入学はありますか？",  # question
+      "expected_response": "はい、あります！AO入学制度は、学力試験だけでは評価できない個性や意欲を重視した入学選考方法です。"  # 模範解答
     },
 ]
 

--- a/RAG_eval.py
+++ b/RAG_eval.py
@@ -1,6 +1,7 @@
 # Databricks notebook source
 # MAGIC %pip install databricks-langchain=0.1.1 langchain_cohere=0.2.4
 # MAGIC %pip install -U -qqqq databricks-agents mlflow mlflow-skinny databricks-vectorsearch langchain==0.2.11 langchain_core==0.2.23 langchain_community==0.2.10 openai
+# MAGIC %pip install python-dotenv
 
 # COMMAND ----------
 
@@ -210,12 +211,16 @@ registered_agent.invoke(input_example)
 import os
 import mlflow
 from databricks import agents
+import os
 
 # modelをdeployする
 deployment_info = agents.deploy(
     model_name,
     uc_model_info.version,
     scale_to_zero=True,
+    environment_vars={
+       'COHERE_API_KEY': os.environ['COHERE_API_KEY'],
+    }
 )
 
 browser_url = mlflow.utils.databricks_utils.get_browser_hostname()

--- a/RAG_eval.py
+++ b/RAG_eval.py
@@ -1,5 +1,6 @@
 # Databricks notebook source
-# MAGIC %pip install databricks-langchain=0.1.1 langchain_cohere=0.2.4
+# MAGIC %pip install databricks-langchain=0.1.1 
+# MAGIC %pip install cohere
 # MAGIC %pip install -U -qqqq databricks-agents mlflow mlflow-skinny databricks-vectorsearch langchain==0.2.11 langchain_core==0.2.23 langchain_community==0.2.10 openai
 # MAGIC %pip install python-dotenv
 
@@ -211,7 +212,7 @@ registered_agent.invoke(input_example)
 import os
 import mlflow
 from databricks import agents
-import os
+import os 
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -223,7 +224,7 @@ deployment_info = agents.deploy(
     scale_to_zero=True,
     environment_vars={
        'COHERE_API_KEY': os.environ['COHERE_API_KEY'],
-    }
+   }
 )
 
 browser_url = mlflow.utils.databricks_utils.get_browser_hostname()

--- a/RAG_eval.py
+++ b/RAG_eval.py
@@ -212,6 +212,9 @@ import os
 import mlflow
 from databricks import agents
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # modelをdeployする
 deployment_info = agents.deploy(

--- a/RAG_eval.py
+++ b/RAG_eval.py
@@ -1,5 +1,5 @@
 # Databricks notebook source
-# MAGIC %pip install databricks-langchain=0.1.1
+# MAGIC %pip install databricks-langchain=0.1.1 langchain_cohere=0.2.4
 # MAGIC %pip install -U -qqqq databricks-agents mlflow mlflow-skinny databricks-vectorsearch langchain==0.2.11 langchain_core==0.2.23 langchain_community==0.2.10 openai
 
 # COMMAND ----------

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -335,9 +335,6 @@ def conditional_retriever(queries: list[str], retriever: VectorStoreRetriever, h
 
         # # 重複除去処理
         docs = list({doc.page_content: doc for doc in docs}.values())
-        print("-"*40)
-        print(len(docs))
-        print(docs)
         return format_context_fn(docs)
 
 
@@ -399,11 +396,6 @@ def rewrite_question(model: ChatDatabricks, question: str) -> list[str]:
 
 # COMMAND ----------
 
-question = "スーパーAIクリエイター専攻って何するの?"
-rewrite_question(model, question)
-
-# COMMAND ----------
-
 from langchain_cohere import CohereRerank
 
 # COMMAND ----------
@@ -444,7 +436,7 @@ input_example = {
 #   "messages": [{"role": "user", "content": "プログラマとは？"}]
 }
 
-chain.invoke(input_example)
+# chain.invoke(input_example)
 
 # COMMAND ----------
 

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -173,7 +173,7 @@ mlflow.models.set_retriever_schema(
 # Method to format the docs returned by the retriever into the prompt
 ############
 def format_context(docs: list[Document]) -> str:
-    chunk_template = "Passage: {chunk_text}\n"
+    chunk_template = "\nPassage: {chunk_text}\n"
     chunk_contents = [
         chunk_template.format(
             chunk_text=d.page_content,
@@ -335,6 +335,9 @@ def conditional_retriever(queries: list[str], retriever: VectorStoreRetriever, h
 
         # # 重複除去処理
         docs = list({doc.page_content: doc for doc in docs}.values())
+        # d.metadata["score"]でsort
+        docs.sort(key=lambda d: d.metadata["score"], reverse=True)
+
         return format_context_fn(docs)
 
 
@@ -381,7 +384,7 @@ def rewrite_question(model: ChatDatabricks, question: str) -> list[str]:
 - より専門的な表現（1つ）
 - 詳細化したバージョン（1つ）
 
-出力はカンマ区切りで記述してください。
+出力は必ず**カンマ(',')区切り**で記述してください。
 例: 要約, 言い換え1, 言い換え2, 言い換え3, 一般向け, 専門的, 詳細版
 """
     rewrite_prompt = ChatPromptTemplate.from_template(rewrite_prompt_template)
@@ -441,7 +444,7 @@ input_example = {
 #   "messages": [{"role": "user", "content": "プログラマとは？"}]
 }
 
-chain.invoke(input_example)
+#chain.invoke(input_example)
 
 # COMMAND ----------
 

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -146,15 +146,12 @@ vector_search_as_retriever = CustomDatabricksVectorSearch(
         "content",
         "url",
     ],
-# ).as_retriever(search_kwargs={
-#     "k": 10,
-#     "query_type": "ann",
-# })
 ).as_retriever(
     search_type="similarity_score_threshold",
     search_kwargs={
         'score_threshold': 0.7,
         'query_type': 'hybrid'
+        'k': 10,
     }
 )
 

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -295,11 +295,12 @@ classification_chain = (
 
 # COMMAND ----------
 
-def select_prompt(context: str) -> ChatPromptTemplate:
+from typing import Optional
+def select_prompt(context: Optional[str]) -> ChatPromptTemplate:
     """
     LLMを使って質問を分類し、それに応じてプロンプトを選択。
     """
-    if context.strip() == "No additional reference information is required for this question.":
+    if context is None:
         # Retrieverがスキップされた場合、一般質問用のプロンプトを使用
         return no_content_prompt
     return rag_prompt
@@ -317,14 +318,14 @@ def is_general_question(question: str) -> bool:
 
 from langchain_core.vectorstores.base import VectorStoreRetriever
 
-def conditional_retriever(queries: list[str], retriever: VectorStoreRetriever, hyde_retriever: VectorStoreRetriever, format_context_fn) -> str:
+def conditional_retriever(queries: list[str], retriever: VectorStoreRetriever, hyde_retriever: VectorStoreRetriever, format_context_fn) -> Optional[str]:
     """
     質問が一般的な場合は検索をスキップし、それ以外の場合はRetrieverを実行する。
     """
     original_query = queries[0]
     if is_general_question(original_query):
         # 検索をスキップして空の参考情報を返す
-        return "No additional reference information is required for this question."
+        return None
     else:
         all_docs = []
         for q in queries:
@@ -339,6 +340,10 @@ def conditional_retriever(queries: list[str], retriever: VectorStoreRetriever, h
         docs.sort(key=lambda d: d.metadata["score"], reverse=True)
 
         return format_context_fn(docs)
+
+
+# COMMAND ----------
+
 
 
 # COMMAND ----------
@@ -444,7 +449,7 @@ input_example = {
 #   "messages": [{"role": "user", "content": "プログラマとは？"}]
 }
 
-#chain.invoke(input_example)
+# chain.invoke(input_example)
 
 # COMMAND ----------
 

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -498,7 +498,7 @@ input_example = {
 #   "messages": [{"role": "user", "content": "プログラマとは？"}]
 }
 
-chain.invoke(input_example)
+# chain.invoke(input_example)
 
 # COMMAND ----------
 

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -352,9 +352,13 @@ def conditional_retriever(queries: list[str], retriever: VectorStoreRetriever, h
         # d.metadata["score"]でsort
         unique_docs.sort(key=lambda d: d.metadata["score"], reverse=True)
 
-        set_retrieved_documents_for_mlflow(unique_docs)
+        # 上位10つのdocsを取得(仮)
+        context_num = 10
+        docs = unique_docs[:context_num]
 
-        return format_context_fn(unique_docs)
+        set_retrieved_documents_for_mlflow(docs)
+
+        return format_context_fn(docs)
 
 
 # COMMAND ----------

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -413,7 +413,7 @@ chain = (
         "context": itemgetter("messages")
         | RunnableLambda(extract_user_query_string)
         | RunnableLambda(
-            lambda question: rewrite_question(model, question)
+            lambda question: rewrite_question(mini_model, question)
         )
         | RunnableLambda(
             lambda queries: conditional_retriever(

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -150,7 +150,7 @@ vector_search_as_retriever = CustomDatabricksVectorSearch(
     search_type="similarity_score_threshold",
     search_kwargs={
         'score_threshold': 0.7,
-        'query_type': 'hybrid'
+        'query_type': 'hybrid',
         'k': 10,
     }
 )

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -369,17 +369,18 @@ rerank_model = CohereRerank(
     model="rerank-v3.5",
 )
 
-def rerank_docs(query: str, docs: list[Document]) -> list[Document]:
+def rerank_docs(query: str, docs: list[Document], top_n: int = 5) -> list[Document]:
+    reranked_docs_idx_and_score = rerank_model.rerank(
+        query=query,
+        documents=docs,
+        top_n=top_n,
+        model="rerank-v3.5",
+    )
 
-    # reranked_docs = rerank_model.rerank(docs)
-
-    # mock
-
-    # 上位10つのdocsを取得(仮)
-    context_num = 10
-    reranked_docs = docs[:context_num]
-
-    # ...
+    reranked_docs = []
+    for reranked_doc_idx, score in reranked_docs_idx_and_score:
+        docs[int(reranked_doc_idx)].metadata["relevance_score"] = score
+        reranked_docs.append(docs[reranked_doc_idx])
 
     set_retrieved_documents_for_mlflow(reranked_docs)
 

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -321,7 +321,8 @@ def conditional_retriever(queries: list[str], retriever: VectorStoreRetriever, h
     """
     質問が一般的な場合は検索をスキップし、それ以外の場合はRetrieverを実行する。
     """
-    if is_general_question(question):
+    original_query = queries[0]
+    if is_general_question(original_query):
         # 検索をスキップして空の参考情報を返す
         return "No additional reference information is required for this question."
     else:
@@ -330,7 +331,6 @@ def conditional_retriever(queries: list[str], retriever: VectorStoreRetriever, h
             docs = retriever.invoke(q)
             all_docs.extend(docs)
         # HyDEを実行
-        original_query = queries[0]
         all_docs.extend(hyde_retriever.invoke({"question": original_query}))
 
         # # 重複除去処理
@@ -441,7 +441,7 @@ input_example = {
 #   "messages": [{"role": "user", "content": "プログラマとは？"}]
 }
 
-# chain.invoke(input_example)
+chain.invoke(input_example)
 
 # COMMAND ----------
 

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -342,6 +342,8 @@ def conditional_retriever(queries: list[str], retriever: VectorStoreRetriever, h
     else:
         all_docs = []
         for q in queries:
+            if q == '':
+                continue
             docs = retriever.invoke(q)
             all_docs.extend(docs)
         # HyDEを実行
@@ -370,7 +372,7 @@ rerank_model = CohereRerank(
 )
 
 def rerank_docs(query: str, docs: list[Document], top_n: int = 5) -> list[Document]:
-    reranked_docs_idx_and_score = rerank_model.rerank(
+    reranked_docs_idx_and_score_list = rerank_model.rerank(
         query=query,
         documents=docs,
         top_n=top_n,
@@ -378,8 +380,9 @@ def rerank_docs(query: str, docs: list[Document], top_n: int = 5) -> list[Docume
     )
 
     reranked_docs = []
-    for reranked_doc_idx, score in reranked_docs_idx_and_score:
-        docs[int(reranked_doc_idx)].metadata["relevance_score"] = score
+    for reranked_doc_idx_and_score in reranked_docs_idx_and_score_list:
+        reranked_doc_idx = reranked_doc_idx_and_score['index']
+        docs[reranked_doc_idx].metadata["relevance_score"] = reranked_doc_idx_and_score['relevance_score']
         reranked_docs.append(docs[reranked_doc_idx])
 
     set_retrieved_documents_for_mlflow(reranked_docs)

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -321,9 +321,13 @@ from mlflow.tracing.constant import SpanAttributeKey
 import json
 from mlflow.entities import SpanType
 
-# mlflowとMosaic AI Agent Evaluation(databricksのLLM-as-a-Judge)の仕様上、Context sufficientとGroundednessの評価のために使われるdocsは、mlflowでRETRIEVER属性が付いているspanの中で最後にトレースされたdocsを取ってくる。
-# そのため、下記関数を呼ばない実装だと、HyDEで取得したdocsのみが回答に使うために取得してきたdocsとして判定されてしまう。
-# なのでここでは、全てのdocsを持った、新たなRETRIEVER属性のspanを作ることで、全てのdocsを回答に使うために取得してきたdocsとして認識させるようにしている。
+# mlflowとMosaic AI Agent Evaluation (DatabricksのLLM-as-a-Judge) の仕様上、
+# Context Sufficient と Groundedness の評価に使われるdocsは、
+# mlflowでRETRIEVER属性が付いたspanの中でも最後にトレースされたものが対象となる。
+#
+# この関数を使わない場合、HyDEで取得したdocsのみが「回答に使用するために取得したdocs」と判定されてしまう。
+# そこで、新たにRETRIEVER属性を持つspanを作成し、すべてのdocsを含めることで、
+# 正しく評価対象として認識されるようにする。
 def set_retrieved_documents_for_mlflow(docs: list[Document]) -> None:
     with mlflow.tracing.fluent.start_span(
         name="final_retrieved_docs",

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -1,5 +1,5 @@
 # Databricks notebook source
-# MAGIC %pip install databricks-langchain=0.1.1
+# MAGIC %pip install databricks-langchain=0.1.1 langchain_cohere=0.2.4
 # MAGIC %pip install mlflow lxml==4.9.3 transformers==4.30.2 databricks-vectorsearch==0.38 databricks-sdk==0.28.0 databricks-feature-store==0.17.0 langchain==0.2.11 langchain_core==0.2.23 langchain-community==0.2.9 databricks-agents
 # MAGIC
 # MAGIC # %pip install databricks-langchain langchain==0.2.11 langchain-core==0.2.23 langchain-community==0.2.9
@@ -352,6 +352,10 @@ rephrase_retriever = RePhraseQueryRetriever.from_llm(
     llm = model,
     prompt = hyde_prompt,
 )
+
+# COMMAND ----------
+
+from langchain_cohere import CohereRerank
 
 # COMMAND ----------
 

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -335,15 +335,11 @@ def conditional_retriever(queries: list[str], retriever: VectorStoreRetriever, h
         all_docs.extend(hyde_retriever.invoke({"question": original_query}))
 
         # # 重複除去処理
-        docs = list({doc.page_content: doc for doc in docs}.values())
+        unique_docs = list({doc.page_content: doc for doc in all_docs}.values())
         # d.metadata["score"]でsort
-        docs.sort(key=lambda d: d.metadata["score"], reverse=True)
+        unique_docs.sort(key=lambda d: d.metadata["score"], reverse=True)
 
-        return format_context_fn(docs)
-
-
-# COMMAND ----------
-
+        return format_context_fn(unique_docs)
 
 
 # COMMAND ----------

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -355,6 +355,47 @@ rephrase_retriever = RePhraseQueryRetriever.from_llm(
 
 # COMMAND ----------
 
+# 質問のre-write
+def rewrite_question(model: ChatDatabricks, question: str) -> list[str]:
+    rewrite_prompt_template = """
+
+あなたは、検索エンジンの精度を向上させるAIアシスタントです。
+ユーザーが入力したクエリをもとに、より効果的な検索を行うためのバリエーションを作成してください。
+質問には答えず、バリエーションを作ることに専念してください。
+
+質問: {original_query}
+
+- 言い換え（3つ）
+- シンプルな要約表現
+- より一般的な表現（1つ）
+- より専門的な表現（1つ）
+- 詳細化したバージョン（1つ）
+
+出力はカンマ区切りで記述してください。
+例: 要約, 言い換え1, 言い換え2, 言い換え3, 一般向け, 専門的, 詳細版
+"""
+    rewrite_prompt = ChatPromptTemplate.from_template(rewrite_prompt_template)
+
+    rewrite_chain = (
+        rewrite_prompt
+        | model
+        | StrOutputParser()
+    )
+
+    response = rewrite_chain.invoke({"original_query": question})
+    try:
+        query = response.split(",")
+        return query
+    except:
+        return []
+
+# COMMAND ----------
+
+question = "スーパーAIクリエイター専攻って何するの?"
+rewrite_question(model, question)
+
+# COMMAND ----------
+
 from langchain_cohere import CohereRerank
 
 # COMMAND ----------

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -172,7 +172,7 @@ mlflow.models.set_retriever_schema(
 ############
 # Method to format the docs returned by the retriever into the prompt
 ############
-def format_context(docs):
+def format_context(docs: list[Document]) -> str:
     chunk_template = "Passage: {chunk_text}\n"
     chunk_contents = [
         chunk_template.format(

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -151,7 +151,7 @@ vector_search_as_retriever = CustomDatabricksVectorSearch(
     search_kwargs={
         'score_threshold': 0.7,
         'query_type': 'hybrid',
-        'k': 10,
+        'k': 20,
     }
 )
 

--- a/chain_langchain.py
+++ b/chain_langchain.py
@@ -329,7 +329,6 @@ def conditional_retriever(queries: list[str], retriever: VectorStoreRetriever, h
         for q in queries:
             docs = retriever.invoke(q)
             all_docs.extend(docs)
-            time.sleep(0.1)
         # HyDEを実行
         original_query = queries[0]
         all_docs.extend(hyde_retriever.invoke({"question": original_query}))


### PR DESCRIPTION
CohereのRerank v3.5を使用して、Rerankを実装する。
その際、rerankするためのドキュメントを大量に取ってくるように、たくさんのクエリを作って、各クエリ20個くらいドキュメントを拾ってくるようにしています。
それらのドキュメント群からよりクエリと関連性の高い上位5つのドキュメントを拾ってくるようにしています。

- Close: #27 
- Close: #28 